### PR TITLE
API Refactoring - Improved encapsulation & simplified method signatures

### DIFF
--- a/Bukkit/src/main/java/me/egg82/tfaplus/BukkitBootstrap.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/BukkitBootstrap.java
@@ -1,13 +1,5 @@
 package me.egg82.tfaplus;
 
-import java.io.*;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.logging.Level;
 import me.egg82.tfaplus.utils.LogUtil;
 import ninja.egg82.core.JarDep;
 import ninja.egg82.services.ProxiedURLClassLoader;
@@ -18,6 +10,16 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.logging.Level;
 
 public class BukkitBootstrap extends JavaPlugin {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
@@ -7,11 +7,6 @@ import co.aikar.taskchain.TaskChainFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.logging.Level;
-
 import me.egg82.tfaplus.commands.HOTPCommand;
 import me.egg82.tfaplus.commands.TFAPlusCommand;
 import me.egg82.tfaplus.core.SQLFetchResult;
@@ -53,6 +48,11 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.logging.Level;
 
 public class TFAPlus {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
@@ -172,14 +172,14 @@ public class TFAPlus {
         if (cachedConfig.getSQLType() == SQLType.MySQL) {
             MySQL.createTables(cachedConfig.getSQL(), config.getNode("storage")).thenRun(() ->
                     MySQL.loadInfo(cachedConfig.getSQL(), config.getNode("storage")).thenAccept(v -> {
-                        Redis.updateFromQueue(v, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"));
+                        Redis.updateFromQueue(v, cachedConfig.getIPTime());
                         updateSQL();
                     })
             );
         } else if (cachedConfig.getSQLType() == SQLType.SQLite) {
             SQLite.createTables(cachedConfig.getSQL(), config.getNode("storage")).thenRun(() ->
                     SQLite.loadInfo(cachedConfig.getSQL(), config.getNode("storage")).thenAccept(v -> {
-                        Redis.updateFromQueue(v, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"));
+                        Redis.updateFromQueue(v, cachedConfig.getIPTime());
                         updateSQL();
                     })
             );
@@ -201,13 +201,13 @@ public class TFAPlus {
         if (cachedConfig.getSQLType() == SQLType.MySQL) {
             MySQL.createTables(cachedConfig.getSQL(), config.getNode("storage")).thenRun(() ->
                     MySQL.loadInfo(cachedConfig.getSQL(), config.getNode("storage")).thenAccept(v -> {
-                        Redis.updateFromQueue(v, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"));
+                        Redis.updateFromQueue(v, cachedConfig.getIPTime());
                     })
             );
         } else if (cachedConfig.getSQLType() == SQLType.SQLite) {
             SQLite.createTables(cachedConfig.getSQL(), config.getNode("storage")).thenRun(() ->
                     SQLite.loadInfo(cachedConfig.getSQL(), config.getNode("storage")).thenAccept(v -> {
-                        Redis.updateFromQueue(v, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"));
+                        Redis.updateFromQueue(v, cachedConfig.getIPTime());
                     })
             );
         }
@@ -240,7 +240,7 @@ public class TFAPlus {
                 }
 
                 if (result != null) {
-                    Redis.updateFromQueue(result, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis")).get();
+                    Redis.updateFromQueue(result, cachedConfig.getIPTime()).get();
                 }
             } catch (ExecutionException ex) {
                 logger.error(ex.getMessage(), ex);

--- a/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/TFAPlus.java
@@ -153,7 +153,7 @@ public class TFAPlus {
             return;
         }
 
-        workPool.submit(() -> new RedisSubscriber(cachedConfig.getRedisPool(), config.getNode("redis")));
+        workPool.submit(() -> new RedisSubscriber());
         ServiceLocator.register(new RabbitMQReceiver(cachedConfig.getRabbitConnectionFactory()));
     }
 

--- a/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/CheckCommand.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/CheckCommand.java
@@ -2,8 +2,6 @@ package me.egg82.tfaplus.commands.internal;
 
 import co.aikar.taskchain.TaskChain;
 import co.aikar.taskchain.TaskChainAbortAction;
-import java.io.IOException;
-import java.util.UUID;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.services.lookup.PlayerLookup;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +9,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
 
 public class CheckCommand implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/DeleteCommand.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/DeleteCommand.java
@@ -2,8 +2,6 @@ package me.egg82.tfaplus.commands.internal;
 
 import co.aikar.taskchain.TaskChain;
 import co.aikar.taskchain.TaskChainAbortAction;
-import java.io.IOException;
-import java.util.UUID;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.services.lookup.PlayerLookup;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +9,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
 
 public class DeleteCommand implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/RegisterAuthyCommand.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/RegisterAuthyCommand.java
@@ -2,8 +2,6 @@ package me.egg82.tfaplus.commands.internal;
 
 import co.aikar.taskchain.TaskChain;
 import co.aikar.taskchain.TaskChainAbortAction;
-import java.io.IOException;
-import java.util.UUID;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.services.lookup.PlayerLookup;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +9,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
 
 public class RegisterAuthyCommand implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/RegisterTOTPCommand.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/commands/internal/RegisterTOTPCommand.java
@@ -2,8 +2,6 @@ package me.egg82.tfaplus.commands.internal;
 
 import co.aikar.taskchain.TaskChain;
 import co.aikar.taskchain.TaskChainAbortAction;
-import java.io.IOException;
-import java.util.UUID;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.extended.Configuration;
 import me.egg82.tfaplus.services.lookup.PlayerLookup;
@@ -17,6 +15,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.UUID;
 
 public class RegisterTOTPCommand implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
@@ -157,13 +157,13 @@ public class AsyncPlayerChatFrozenHandler implements Consumer<AsyncPlayerChatEve
 
     private void setLogin(Configuration config, CachedConfigValues cachedConfig, UUID uuid, String ip) {
         try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+            InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime());
             return;
         } catch (IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         }
 
-        InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime());
     }
 
     private void kickPlayer(Configuration config, Player player) {

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
@@ -158,13 +158,13 @@ public class AsyncPlayerChatFrozenHandler implements Consumer<AsyncPlayerChatEve
 
     private void setLogin(Configuration config, CachedConfigValues cachedConfig, UUID uuid, String ip) {
         try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime());
+            InternalAPI.setLogin(uuid, ip);
             return;
         } catch (IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         }
 
-        InternalAPI.setLogin(uuid, ip, cachedConfig.getIPTime());
+        InternalAPI.setLogin(uuid, ip);
     }
 
     private void kickPlayer(Configuration config, Player player) {

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerChatFrozenHandler.java
@@ -1,14 +1,6 @@
 package me.egg82.tfaplus.events;
 
 import com.rabbitmq.client.Connection;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.extended.Configuration;
@@ -27,6 +19,15 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 public class AsyncPlayerChatFrozenHandler implements Consumer<AsyncPlayerChatEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerPreLoginCacheHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/AsyncPlayerPreLoginCacheHandler.java
@@ -1,7 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.net.InetAddress;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +9,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.util.function.Consumer;
 
 public class AsyncPlayerPreLoginCacheHandler implements Consumer<AsyncPlayerPreLoginEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/BlockBreakFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/BlockBreakFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class BlockBreakFrozenHandler implements Consumer<BlockBreakEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/BlockPlaceFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/BlockPlaceFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class BlockPlaceFrozenHandler implements Consumer<BlockPlaceEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/EntityDamageByEntityFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/EntityDamageByEntityFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +10,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class EntityDamageByEntityFrozenHandler implements Consumer<EntityDamageByEntityEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryClickFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryClickFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class InventoryClickFrozenHandler implements Consumer<InventoryClickEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryDragFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryDragFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class InventoryDragFrozenHandler implements Consumer<InventoryDragEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryMoveItemFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/InventoryMoveItemFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -11,6 +10,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class InventoryMoveItemFrozenHandler implements Consumer<InventoryMoveItemEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerCommandPreprocessFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerCommandPreprocessFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
@@ -11,6 +10,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class PlayerCommandPreprocessFrozenHandler implements Consumer<PlayerCommandPreprocessEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerDropItemFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerDropItemFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class PlayerDropItemFrozenHandler implements Consumer<PlayerDropItemEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerInteractFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerInteractFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -10,6 +9,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class PlayerInteractFrozenHandler implements Consumer<PlayerInteractEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginCheckHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginCheckHandler.java
@@ -100,12 +100,12 @@ public class PlayerLoginCheckHandler implements Consumer<PlayerLoginEvent> {
 
     private boolean canLogin(Configuration config, CachedConfigValues cachedConfig, UUID uuid, String ip) {
         try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return InternalAPI.getLogin(uuid, ip, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+            return InternalAPI.getLogin(uuid, ip, cachedConfig.getIPTime());
         } catch (IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         }
 
-        return InternalAPI.getLogin(uuid, ip, cachedConfig.getIPTime(), cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return InternalAPI.getLogin(uuid, ip, cachedConfig.getIPTime());
     }
 
     private void kickPlayer(Configuration config, PlayerLoginEvent event) {

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginCheckHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginCheckHandler.java
@@ -1,12 +1,6 @@
 package me.egg82.tfaplus.events;
 
 import com.rabbitmq.client.Connection;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.TFAAPI;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.extended.Configuration;
@@ -23,6 +17,13 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 public class PlayerLoginCheckHandler implements Consumer<PlayerLoginEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginUpdateNotifyHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerLoginUpdateNotifyHandler.java
@@ -1,7 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.concurrent.ExecutionException;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.Configuration;
 import me.egg82.tfaplus.utils.LogUtil;
 import ninja.egg82.service.ServiceLocator;
@@ -13,6 +11,9 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 
 public class PlayerLoginUpdateNotifyHandler implements Consumer<PlayerLoginEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerMoveFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerMoveFrozenHandler.java
@@ -2,9 +2,6 @@ package me.egg82.tfaplus.events;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -15,6 +12,10 @@ import org.bukkit.Location;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public class PlayerMoveFrozenHandler implements Consumer<PlayerMoveEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerPickupArrowFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerPickupArrowFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import ninja.egg82.service.ServiceLocator;
@@ -8,6 +7,8 @@ import ninja.egg82.service.ServiceNotFoundException;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class PlayerPickupArrowFrozenHandler implements Consumer<PlayerPickupArrowEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerPickupItemFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerPickupItemFrozenHandler.java
@@ -1,6 +1,5 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import ninja.egg82.service.ServiceLocator;
@@ -8,6 +7,8 @@ import ninja.egg82.service.ServiceNotFoundException;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 public class PlayerPickupItemFrozenHandler implements Consumer<PlayerPickupItemEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerQuitFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerQuitFrozenHandler.java
@@ -1,8 +1,9 @@
 package me.egg82.tfaplus.events;
 
-import java.util.function.Consumer;
 import me.egg82.tfaplus.services.CollectionProvider;
 import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.function.Consumer;
 
 public class PlayerQuitFrozenHandler implements Consumer<PlayerQuitEvent> {
     public void accept(PlayerQuitEvent event) {

--- a/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerTeleportFrozenHandler.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/events/PlayerTeleportFrozenHandler.java
@@ -2,9 +2,6 @@ package me.egg82.tfaplus.events;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.services.CollectionProvider;
 import me.egg82.tfaplus.utils.LogUtil;
@@ -15,6 +12,10 @@ import org.bukkit.Location;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public class PlayerTeleportFrozenHandler implements Consumer<PlayerTeleportEvent> {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Bukkit/src/main/java/me/egg82/tfaplus/hooks/PlayerAnalyticsHook.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/hooks/PlayerAnalyticsHook.java
@@ -5,9 +5,10 @@ import com.djrapitops.plan.data.element.AnalysisContainer;
 import com.djrapitops.plan.data.element.InspectContainer;
 import com.djrapitops.plan.data.plugin.ContainerSize;
 import com.djrapitops.plan.data.plugin.PluginData;
+import me.egg82.tfaplus.TFAAPI;
+
 import java.util.Collection;
 import java.util.UUID;
-import me.egg82.tfaplus.TFAAPI;
 
 public class PlayerAnalyticsHook implements PluginHook {
     public PlayerAnalyticsHook() { PlanAPI.getInstance().addPluginDataSource(new Data()); }

--- a/Bukkit/src/main/java/me/egg82/tfaplus/renderers/ImageRenderer.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/renderers/ImageRenderer.java
@@ -1,11 +1,12 @@
 package me.egg82.tfaplus.renderers;
 
-import java.awt.image.BufferedImage;
-import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
+
+import java.awt.image.BufferedImage;
+import java.util.UUID;
 
 /**
  * Largely taken from SecureMyAccount

--- a/Bukkit/src/main/java/me/egg82/tfaplus/renderers/QRRenderer.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/renderers/QRRenderer.java
@@ -6,12 +6,13 @@ import com.google.zxing.WriterException;
 import com.google.zxing.client.j2se.MatrixToImageWriter;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
-import java.awt.image.BufferedImage;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import me.egg82.tfaplus.extended.ServiceKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * Largely taken from SecureMyAccount

--- a/Bukkit/src/main/java/me/egg82/tfaplus/services/lookup/BukkitPlayerInfo.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/services/lookup/BukkitPlayerInfo.java
@@ -2,14 +2,6 @@ package me.egg82.tfaplus.services.lookup;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import ninja.egg82.json.JSONUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -18,6 +10,15 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 public class BukkitPlayerInfo implements PlayerInfo {
     private static final Logger logger = LoggerFactory.getLogger(BukkitPlayerInfo.class);

--- a/Bukkit/src/main/java/me/egg82/tfaplus/services/lookup/PaperPlayerInfo.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/services/lookup/PaperPlayerInfo.java
@@ -3,11 +3,12 @@ package me.egg82.tfaplus.services.lookup;
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 
 public class PaperPlayerInfo implements PlayerInfo {
     private UUID uuid;

--- a/Bukkit/src/main/java/me/egg82/tfaplus/utils/BukkitVersionUtil.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/utils/BukkitVersionUtil.java
@@ -2,9 +2,10 @@ package me.egg82.tfaplus.utils;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.List;
 import ninja.egg82.reflect.PackageFilter;
 import org.bukkit.Bukkit;
+
+import java.util.List;
 
 public class BukkitVersionUtil {
     private static String gameVersion = null;

--- a/Bukkit/src/main/java/me/egg82/tfaplus/utils/ConfigurationFileUtil.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/utils/ConfigurationFileUtil.java
@@ -4,14 +4,6 @@ import com.authy.AuthyApiClient;
 import com.google.common.reflect.TypeToken;
 import com.rabbitmq.client.ConnectionFactory;
 import com.zaxxer.hikari.HikariConfig;
-import java.io.*;
-import java.nio.file.Files;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import me.egg82.tfaplus.core.FreezeConfigContainer;
 import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.extended.CachedConfigValues;
@@ -30,6 +22,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import redis.clients.jedis.JedisPool;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class ConfigurationFileUtil {
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationFileUtil.class);

--- a/Bukkit/src/main/java/me/egg82/tfaplus/utils/MapUtil.java
+++ b/Bukkit/src/main/java/me/egg82/tfaplus/utils/MapUtil.java
@@ -1,9 +1,5 @@
 package me.egg82.tfaplus.utils;
 
-import java.awt.image.BufferedImage;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
 import me.egg82.tfaplus.renderers.ImageRenderer;
 import me.egg82.tfaplus.renderers.QRRenderer;
 import org.bukkit.Bukkit;
@@ -14,6 +10,11 @@ import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
 
 /**
  * Largely taken from SecureMyAccount

--- a/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
@@ -13,6 +13,7 @@ import me.egg82.tfaplus.extended.Configuration;
 import me.egg82.tfaplus.services.InternalAPI;
 import me.egg82.tfaplus.sql.MySQL;
 import me.egg82.tfaplus.sql.SQLite;
+import me.egg82.tfaplus.utils.ConfigUtil;
 import me.egg82.tfaplus.utils.RabbitMQUtil;
 import ninja.egg82.service.ServiceLocator;
 import ninja.egg82.service.ServiceNotFoundException;
@@ -102,29 +103,12 @@ public class TFAAPI {
             throw new IllegalArgumentException("countryCode cannot be empty.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return false;
-        }
-
-        if (!cachedConfig.getAuthy().isPresent()) {
+        if (!ConfigUtil.getCachedConfig().getAuthy().isPresent()) {
             logger.error("Authy is not present (missing API key in config?)");
             return false;
         }
 
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.registerAuthy(uuid, email, phone, countryCode, cachedConfig.getAuthy().get().getUsers(), cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
-
-        return internalApi.registerAuthy(uuid, email, phone, countryCode, cachedConfig.getAuthy().get().getUsers(), cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.registerAuthy(uuid, email, phone, countryCode);
     }
 
     /**
@@ -142,24 +126,16 @@ public class TFAAPI {
             throw new IllegalArgumentException("codeLength cannot be <= 0.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return null;
-        }
+        CachedConfigValues cachedConfig = ConfigUtil.getCachedConfig();
+        Configuration config = ConfigUtil.getConfig();
 
         try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.registerTOTP(uuid, codeLength, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+            return internalApi.registerTOTP(uuid, codeLength);
         } catch (IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         }
 
-        return internalApi.registerTOTP(uuid, codeLength, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.registerTOTP(uuid, codeLength);
     }
 
     /**
@@ -190,24 +166,16 @@ public class TFAAPI {
             throw new IllegalArgumentException("initialCounterValue cannot be < 0.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return null;
-        }
+        CachedConfigValues cachedConfig = ConfigUtil.getCachedConfig();
+        Configuration config = ConfigUtil.getConfig();
 
         try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.registerHOTP(uuid, codeLength, initialCounterValue, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+            return internalApi.registerHOTP(uuid, codeLength, initialCounterValue);
         } catch (IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         }
 
-        return internalApi.registerHOTP(uuid, codeLength, initialCounterValue, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.registerHOTP(uuid, codeLength, initialCounterValue);
     }
 
     /**
@@ -253,24 +221,7 @@ public class TFAAPI {
             throw new IllegalArgumentException("tokens length cannot be <= 1");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return false;
-        }
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.seekHOTPCounter(uuid, tokens, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
-
-        return internalApi.seekHOTPCounter(uuid, tokens, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.seekHOTPCounter(uuid, tokens);
     }
 
     /**
@@ -284,24 +235,7 @@ public class TFAAPI {
             throw new IllegalArgumentException("uuid cannot be null.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return false;
-        }
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.isRegistered(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
-
-        return internalApi.isRegistered(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.isRegistered(uuid);
     }
 
     /**
@@ -315,24 +249,7 @@ public class TFAAPI {
             throw new IllegalArgumentException("uuid cannot be null.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return false;
-        }
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.delete(uuid, cachedConfig.getAuthy().isPresent() ? cachedConfig.getAuthy().get().getUsers() : null, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
-
-        return internalApi.delete(uuid, cachedConfig.getAuthy().isPresent() ? cachedConfig.getAuthy().get().getUsers() : null, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+        return internalApi.delete(uuid, ConfigUtil.getCachedConfig().getAuthy().isPresent() ? ConfigUtil.getCachedConfig().getAuthy().get().getUsers() : null);
     }
 
     /**
@@ -368,39 +285,18 @@ public class TFAAPI {
             throw new IllegalArgumentException("token cannot be empty.");
         }
 
-        CachedConfigValues cachedConfig;
-        Configuration config;
-
-        try {
-            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
-            config = ServiceLocator.get(Configuration.class);
-        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
-            logger.error(ex.getMessage(), ex);
-            return Optional.empty();
-        }
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            if (cachedConfig.getAuthy().isPresent() && internalApi.hasAuthy(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-                return internalApi.verifyAuthy(uuid, token, cachedConfig.getAuthy().get().getTokens(), cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-            } else if (internalApi.hasTOTP(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-                return internalApi.verifyTOTP(uuid, token, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-            } else if (internalApi.hasHOTP(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-                return internalApi.verifyHOTP(uuid, token, cachedConfig.getRedisPool(), config.getNode("redis"), rabbitConnection, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
+            if (ConfigUtil.getAuthy().isPresent() && internalApi.hasAuthy(uuid)) {
+                return internalApi.verifyAuthy(uuid, token);
+            } else if (internalApi.hasTOTP(uuid)) {
+                return internalApi.verifyTOTP(uuid, token);
+            } else if (internalApi.hasHOTP(uuid)) {
+                return internalApi.verifyHOTP(uuid, token);
             } else {
                 return Optional.empty();
             }
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
+    }
 
-        if (cachedConfig.getAuthy().isPresent() && internalApi.hasAuthy(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-            return internalApi.verifyAuthy(uuid, token, cachedConfig.getAuthy().get().getTokens(), cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } else if (internalApi.hasTOTP(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-            return internalApi.verifyTOTP(uuid, token, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } else if (internalApi.hasHOTP(uuid, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug())) {
-            return internalApi.verifyHOTP(uuid, token, cachedConfig.getRedisPool(), config.getNode("redis"), null, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType(), cachedConfig.getDebug());
-        } else {
-            return Optional.empty();
-        }
+    public static Logger getLogger() {
+        return logger;
     }
 }

--- a/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
@@ -1,25 +1,20 @@
 package me.egg82.tfaplus;
 
-import com.rabbitmq.client.Connection;
 import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.extended.CachedConfigValues;
-import me.egg82.tfaplus.extended.Configuration;
 import me.egg82.tfaplus.services.InternalAPI;
 import me.egg82.tfaplus.sql.MySQL;
 import me.egg82.tfaplus.sql.SQLite;
 import me.egg82.tfaplus.utils.ConfigUtil;
-import me.egg82.tfaplus.utils.RabbitMQUtil;
 import ninja.egg82.service.ServiceLocator;
 import ninja.egg82.service.ServiceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 public class TFAAPI {
     private static final Logger logger = LoggerFactory.getLogger(TFAAPI.class);
@@ -127,15 +122,6 @@ public class TFAAPI {
             throw new IllegalArgumentException("codeLength cannot be <= 0.");
         }
 
-        CachedConfigValues cachedConfig = ConfigUtil.getCachedConfig();
-        Configuration config = ConfigUtil.getConfig();
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.registerTOTP(uuid, codeLength);
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
-        }
-
         return internalApi.registerTOTP(uuid, codeLength);
     }
 
@@ -165,15 +151,6 @@ public class TFAAPI {
         }
         if (initialCounterValue < 0) {
             throw new IllegalArgumentException("initialCounterValue cannot be < 0.");
-        }
-
-        CachedConfigValues cachedConfig = ConfigUtil.getCachedConfig();
-        Configuration config = ConfigUtil.getConfig();
-
-        try (Connection rabbitConnection = RabbitMQUtil.getConnection(cachedConfig.getRabbitConnectionFactory())) {
-            return internalApi.registerHOTP(uuid, codeLength, initialCounterValue);
-        } catch (IOException | TimeoutException ex) {
-            logger.error(ex.getMessage(), ex);
         }
 
         return internalApi.registerHOTP(uuid, codeLength, initialCounterValue);

--- a/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/TFAAPI.java
@@ -1,12 +1,6 @@
 package me.egg82.tfaplus;
 
 import com.rabbitmq.client.Connection;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.extended.Configuration;
@@ -19,6 +13,13 @@ import ninja.egg82.service.ServiceLocator;
 import ninja.egg82.service.ServiceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 public class TFAAPI {
     private static final Logger logger = LoggerFactory.getLogger(TFAAPI.class);

--- a/Common/src/main/java/me/egg82/tfaplus/core/TOTPData.java
+++ b/Common/src/main/java/me/egg82/tfaplus/core/TOTPData.java
@@ -1,9 +1,10 @@
 package me.egg82.tfaplus.core;
 
-import java.util.UUID;
+import me.egg82.tfaplus.extended.ServiceKeys;
+
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import me.egg82.tfaplus.extended.ServiceKeys;
+import java.util.UUID;
 
 public class TOTPData {
     private final UUID uuid;

--- a/Common/src/main/java/me/egg82/tfaplus/extended/CachedConfigValues.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/CachedConfigValues.java
@@ -3,15 +3,16 @@ package me.egg82.tfaplus.extended;
 import com.authy.AuthyApiClient;
 import com.google.common.collect.ImmutableSet;
 import com.rabbitmq.client.ConnectionFactory;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import me.egg82.tfaplus.core.FreezeConfigContainer;
 import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.services.InternalAPI;
 import ninja.egg82.sql.SQL;
 import ninja.egg82.tuples.longs.LongObjectPair;
 import redis.clients.jedis.JedisPool;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class CachedConfigValues {
     private CachedConfigValues() {}

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RabbitMQReceiver.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RabbitMQReceiver.java
@@ -1,10 +1,6 @@
 package me.egg82.tfaplus.extended;
 
 import com.rabbitmq.client.*;
-import java.io.IOException;
-import java.util.Base64;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 import me.egg82.tfaplus.core.AuthyData;
 import me.egg82.tfaplus.core.HOTPData;
 import me.egg82.tfaplus.core.LoginData;
@@ -20,6 +16,11 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 public class RabbitMQReceiver {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RabbitMQReceiver.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RabbitMQReceiver.java
@@ -88,7 +88,7 @@ public class RabbitMQReceiver {
                         CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                         Configuration config = ServiceLocator.get(Configuration.class);
 
-                        InternalAPI.add(new LoginData(uuid, ip, created), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                        InternalAPI.add(new LoginData(uuid, ip, created));
                     } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                         logger.error(ex.getMessage(), ex);
                     }
@@ -120,7 +120,7 @@ public class RabbitMQReceiver {
                         CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                         Configuration config = ServiceLocator.get(Configuration.class);
 
-                        InternalAPI.add(new AuthyData(uuid, i), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                        InternalAPI.add(new AuthyData(uuid, i));
                     } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                         logger.error(ex.getMessage(), ex);
                     }
@@ -153,7 +153,7 @@ public class RabbitMQReceiver {
                         CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                         Configuration config = ServiceLocator.get(Configuration.class);
 
-                        InternalAPI.add(new TOTPData(uuid, length, key), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                        InternalAPI.add(new TOTPData(uuid, length, key));
                     } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                         logger.error(ex.getMessage(), ex);
                     }
@@ -187,7 +187,7 @@ public class RabbitMQReceiver {
                         CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                         Configuration config = ServiceLocator.get(Configuration.class);
 
-                        InternalAPI.add(new HOTPData(uuid, length, counter, key), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                        InternalAPI.add(new HOTPData(uuid, length, counter, key));
                     } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                         logger.error(ex.getMessage(), ex);
                     }
@@ -211,7 +211,7 @@ public class RabbitMQReceiver {
                     }
 
                     // In this case, the message is the "UUID"
-                    InternalAPI.delete(message, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                    InternalAPI.delete(message);
                 }
             };
             channel.basicConsume(deleteQueueName, true, deleteConsumer);

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
@@ -30,7 +30,7 @@ public class RedisSubscriber {
     private static Base64.Decoder decoder = Base64.getDecoder();
 
     public RedisSubscriber(JedisPool pool, ConfigurationNode redisConfigNode) {
-        try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+        try (Jedis redis = RedisUtil.getRedis()) {
             if (redis == null) {
                 return;
             }

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
@@ -11,13 +11,11 @@ import me.egg82.tfaplus.utils.ValidationUtil;
 import ninja.egg82.analytics.utils.JSONUtil;
 import ninja.egg82.service.ServiceLocator;
 import ninja.egg82.service.ServiceNotFoundException;
-import ninja.leaping.configurate.ConfigurationNode;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.exceptions.JedisException;
 
@@ -29,7 +27,7 @@ public class RedisSubscriber {
 
     private static Base64.Decoder decoder = Base64.getDecoder();
 
-    public RedisSubscriber(JedisPool pool, ConfigurationNode redisConfigNode) {
+    public RedisSubscriber() {
         try (Jedis redis = RedisUtil.getRedis()) {
             if (redis == null) {
                 return;

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
@@ -1,7 +1,5 @@
 package me.egg82.tfaplus.extended;
 
-import java.util.Base64;
-import java.util.UUID;
 import me.egg82.tfaplus.core.AuthyData;
 import me.egg82.tfaplus.core.HOTPData;
 import me.egg82.tfaplus.core.LoginData;
@@ -22,6 +20,9 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.Base64;
+import java.util.UUID;
 
 public class RedisSubscriber {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
+++ b/Common/src/main/java/me/egg82/tfaplus/extended/RedisSubscriber.java
@@ -65,7 +65,7 @@ public class RedisSubscriber {
                     CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                     Configuration config = ServiceLocator.get(Configuration.class);
 
-                    InternalAPI.add(new LoginData(uuid, ip, created), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                    InternalAPI.add(new LoginData(uuid, ip, created));
                 } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                     logger.error(ex.getMessage(), ex);
                 }
@@ -84,7 +84,7 @@ public class RedisSubscriber {
                     CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                     Configuration config = ServiceLocator.get(Configuration.class);
 
-                    InternalAPI.add(new AuthyData(uuid, i), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                    InternalAPI.add(new AuthyData(uuid, i));
                 } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                     logger.error(ex.getMessage(), ex);
                 }
@@ -104,7 +104,7 @@ public class RedisSubscriber {
                     CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                     Configuration config = ServiceLocator.get(Configuration.class);
 
-                    InternalAPI.add(new TOTPData(uuid, length, key), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                    InternalAPI.add(new TOTPData(uuid, length, key));
                 } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                     logger.error(ex.getMessage(), ex);
                 }
@@ -125,7 +125,7 @@ public class RedisSubscriber {
                     CachedConfigValues cachedConfig = ServiceLocator.get(CachedConfigValues.class);
                     Configuration config = ServiceLocator.get(Configuration.class);
 
-                    InternalAPI.add(new HOTPData(uuid, length, counter, key), cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                    InternalAPI.add(new HOTPData(uuid, length, counter, key));
                 } catch (ParseException | ClassCastException | NullPointerException | IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
                     logger.error(ex.getMessage(), ex);
                 }
@@ -142,7 +142,7 @@ public class RedisSubscriber {
                 }
 
                 // In this case, the message is the "UUID"
-                InternalAPI.delete(message, cachedConfig.getSQL(), config.getNode("storage"), cachedConfig.getSQLType());
+                InternalAPI.delete(message);
             }
         }
     }

--- a/Common/src/main/java/me/egg82/tfaplus/services/GameAnalyticsErrorHandler.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/GameAnalyticsErrorHandler.java
@@ -1,9 +1,5 @@
 package me.egg82.tfaplus.services;
 
-import java.io.IOException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.UUID;
 import me.egg82.tfaplus.extended.ServiceKeys;
 import ninja.egg82.analytics.GameAnalytics;
 import ninja.egg82.analytics.common.Severity;
@@ -12,6 +8,11 @@ import ninja.egg82.analytics.events.GASessionEnd;
 import ninja.egg82.analytics.events.GASessionStart;
 import ninja.egg82.analytics.events.base.GAEventBase;
 import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 
 public class GameAnalyticsErrorHandler {
     private static GameAnalytics gameAnalytics = null;

--- a/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
@@ -1,23 +1,15 @@
 package me.egg82.tfaplus.services;
 
 import com.authy.AuthyException;
-import com.authy.api.*;
+import com.authy.api.Hash;
+import com.authy.api.Token;
+import com.authy.api.User;
+import com.authy.api.Users;
 import com.eatthepath.otp.HmacOneTimePasswordGenerator;
 import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-
-import java.io.IOException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
-
 import com.rabbitmq.client.Connection;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -32,6 +24,16 @@ import ninja.egg82.tuples.objects.ObjectObjectPair;
 import org.apache.commons.codec.binary.Base32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class InternalAPI {
     private static final Logger logger = LoggerFactory.getLogger(InternalAPI.class);

--- a/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
@@ -7,16 +7,18 @@ import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.rabbitmq.client.Connection;
+
+import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
+import com.rabbitmq.client.Connection;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import me.egg82.tfaplus.core.*;
@@ -24,13 +26,12 @@ import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.extended.ServiceKeys;
 import me.egg82.tfaplus.sql.MySQL;
 import me.egg82.tfaplus.sql.SQLite;
-import ninja.egg82.sql.SQL;
+import me.egg82.tfaplus.utils.ConfigUtil;
+import me.egg82.tfaplus.utils.RabbitMQUtil;
 import ninja.egg82.tuples.objects.ObjectObjectPair;
-import ninja.leaping.configurate.ConfigurationNode;
 import org.apache.commons.codec.binary.Base32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.JedisPool;
 
 public class InternalAPI {
     private static final Logger logger = LoggerFactory.getLogger(InternalAPI.class);
@@ -47,36 +48,36 @@ public class InternalAPI {
         verificationCache = Caffeine.newBuilder().expireAfterWrite(duration, unit).build(k -> Boolean.FALSE);
     }
 
-    public static void add(LoginData data, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
+    public static void add(LoginData data) {
         loginCache.put(new ObjectObjectPair<>(data.getUUID(), data.getIP()), Boolean.TRUE);
-        if (sqlType == SQLType.SQLite) {
-            SQLite.addLogin(data, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.addLogin(data, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
-    public static void add(AuthyData data, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
+    public static void add(AuthyData data) {
         authyCache.put(data.getUUID(), data.getID());
-        if (sqlType == SQLType.SQLite) {
-            SQLite.addAuthy(data, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.addAuthy(data, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
-    public static void add(TOTPData data, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
+    public static void add(TOTPData data) {
         totpCache.put(data.getUUID(), new TOTPCacheData(data.getLength(), data.getKey()));
-        if (sqlType == SQLType.SQLite) {
-            SQLite.addTOTP(data, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.addTOTP(data, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
-    public static void add(HOTPData data, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
+    public static void add(HOTPData data) {
         hotpCache.put(data.getUUID(), new HOTPCacheData(data.getLength(), data.getCounter(), data.getKey()));
-        if (sqlType == SQLType.SQLite) {
-            SQLite.addHOTP(data, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.addHOTP(data, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
-    public String registerHOTP(UUID uuid, long codeLength, long initialCounter, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public String registerHOTP(UUID uuid, long codeLength, long initialCounter) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Registering HOTP " + uuid);
         }
 
@@ -95,36 +96,25 @@ public class InternalAPI {
 
         // SQL
         HOTPData result = null;
-        try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateHOTP(sql, storageConfigNode, uuid, codeLength, initialCounter, key).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateHOTP(sql, storageConfigNode, uuid, codeLength, initialCounter, key).get();
-            }
-        } catch (ExecutionException ex) {
-            logger.error(ex.getMessage(), ex);
-        } catch (InterruptedException ex) {
-            logger.error(ex.getMessage(), ex);
-            Thread.currentThread().interrupt();
-        }
+        result = getHotpData(uuid, codeLength, initialCounter, key, result);
 
         if (result == null) {
             return null;
         }
 
         // Redis
-        Redis.update(result, redisPool, redisConfigNode);
+        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
-        RabbitMQ.broadcast(result, rabbitConnection);
+        broadcastResult(result);
 
         hotpCache.put(uuid, new HOTPCacheData(codeLength, result.getCounter(), key));
 
         return encoder.encodeToString(key.getEncoded());
     }
 
-    public String registerTOTP(UUID uuid, long codeLength, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public String registerTOTP(UUID uuid, long codeLength) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Registering TOTP " + uuid);
         }
 
@@ -144,10 +134,10 @@ public class InternalAPI {
         // SQL
         TOTPData result = null;
         try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateTOTP(sql, storageConfigNode, uuid, codeLength, key).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateTOTP(sql, storageConfigNode, uuid, codeLength, key).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.updateTOTP(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, codeLength, key).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.updateTOTP(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, codeLength, key).get();
             }
         } catch (ExecutionException ex) {
             logger.error(ex.getMessage(), ex);
@@ -161,24 +151,32 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, redisPool, redisConfigNode);
+        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
-        RabbitMQ.broadcast(result, rabbitConnection);
+        try {
+            RabbitMQ.broadcast(result, getRabbitConnection());
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+        }
 
         totpCache.put(uuid, new TOTPCacheData(codeLength, key));
 
         return encoder.encodeToString(key.getEncoded());
     }
 
-    public boolean registerAuthy(UUID uuid, String email, String phone, String countryCode, Users users, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private static Connection getRabbitConnection() throws IOException, TimeoutException {
+        return RabbitMQUtil.getConnection(ConfigUtil.getCachedConfig().getRabbitConnectionFactory());
+    }
+
+    public boolean registerAuthy(UUID uuid, String email, String phone, String countryCode) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Registering Authy " + uuid + " (" + email + ", +" + countryCode + " " + phone + ")");
         }
 
         User user;
         try {
-           user = users.createUser(email, phone, countryCode);
+           user = getAuthyUsers().createUser(email, phone, countryCode);
         } catch (AuthyException ex) {
             logger.error(ex.getMessage(), ex);
             return false;
@@ -192,10 +190,10 @@ public class InternalAPI {
         // SQL
         AuthyData result = null;
         try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateAuthy(sql, storageConfigNode, uuid, user.getId()).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateAuthy(sql, storageConfigNode, uuid, user.getId()).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.updateAuthy(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, user.getId()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.updateAuthy(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, user.getId()).get();
             }
         } catch (ExecutionException ex) {
             logger.error(ex.getMessage(), ex);
@@ -209,18 +207,26 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, redisPool, redisConfigNode);
+        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
-        RabbitMQ.broadcast(result, rabbitConnection);
+        try {
+            RabbitMQ.broadcast(result, getRabbitConnection());
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+        }
 
         authyCache.put(uuid, result.getID());
 
         return true;
     }
 
-    public boolean delete(UUID uuid, Users users, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private Users getAuthyUsers() {
+        return ConfigUtil.getAuthy().get().getUsers();
+    }
+
+    public boolean delete(UUID uuid, Users users) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Removing data for " + uuid);
         }
 
@@ -236,10 +242,10 @@ public class InternalAPI {
 
         AuthyData result = null;
         try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.getAuthyData(uuid, sql, storageConfigNode).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.getAuthyData(uuid, sql, storageConfigNode).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.getAuthyData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.getAuthyData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
             }
         } catch (ExecutionException ex) {
             logger.error(ex.getMessage(), ex);
@@ -264,22 +270,30 @@ public class InternalAPI {
         }
 
         // SQL
-        if (sqlType == SQLType.MySQL) {
-            MySQL.delete(uuid, sql, storageConfigNode);
-        } else if (sqlType == SQLType.SQLite) {
-            SQLite.delete(uuid, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+            MySQL.delete(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
+        } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.delete(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
 
         // Redis
-        Redis.delete(uuid, redisPool, redisConfigNode);
+        Redis.delete(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
-        RabbitMQ.delete(uuid, rabbitConnection);
+        rabbitDelete(uuid);
 
         return true;
     }
 
-    public static void delete(UUID uuid, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
+    private void rabbitDelete(UUID uuid) {
+        try {
+            RabbitMQ.delete(uuid, getRabbitConnection());
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void delete(UUID uuid) {
         for (Map.Entry<ObjectObjectPair<UUID, String>, Boolean> kvp : loginCache.asMap().entrySet()) {
             if (uuid.equals(kvp.getKey().getFirst())) {
                 loginCache.invalidate(kvp.getKey());
@@ -289,14 +303,14 @@ public class InternalAPI {
         authyCache.invalidate(uuid);
         verificationCache.invalidate(uuid);
 
-        if (sqlType == SQLType.SQLite) {
-            SQLite.delete(uuid, sql, storageConfigNode);
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.delete(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
-    public static void delete(String uuid, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType) {
-        if (sqlType == SQLType.SQLite) {
-            SQLite.delete(uuid, sql, storageConfigNode);
+    public static void delete(String uuid) {
+        if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+            SQLite.delete(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode());
         }
     }
 
@@ -308,12 +322,12 @@ public class InternalAPI {
         return retVal;
     }
 
-    public Optional<Boolean> verifyAuthy(UUID uuid, String token, Tokens tokens, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public Optional<Boolean> verifyAuthy(UUID uuid, String token) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Verifying Authy " + uuid + " with " + token);
         }
 
-        long id = authyCache.get(uuid, k -> getAuthyExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug));
+        long id = authyCache.get(uuid, k -> getAuthyExpensive(uuid));
         if (id < 0) {
             logger.warn(uuid + " has not been registered.");
             return Optional.empty();
@@ -324,7 +338,7 @@ public class InternalAPI {
 
         Token verification;
         try {
-            verification = tokens.verify((int) id, token, options);
+            verification = ConfigUtil.getTokens().verify((int) id, token, options);
         } catch (AuthyException ex) {
             logger.error(ex.getMessage(), ex);
             return Optional.empty();
@@ -339,8 +353,8 @@ public class InternalAPI {
         return Optional.of(Boolean.TRUE);
     }
 
-    public Optional<Boolean> verifyTOTP(UUID uuid, String token, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public Optional<Boolean> verifyTOTP(UUID uuid, String token) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Verifying TOTP " + uuid + " with " + token);
         }
 
@@ -352,7 +366,7 @@ public class InternalAPI {
             return Optional.of(Boolean.FALSE);
         }
 
-        TOTPCacheData data = totpCache.get(uuid, k -> getTOTPExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug));
+        TOTPCacheData data = totpCache.get(uuid, k -> getTOTPExpensive(uuid));
         if (data == null) {
             logger.warn(uuid + " has not been registered.");
             return Optional.empty();
@@ -387,8 +401,8 @@ public class InternalAPI {
         return Optional.of(Boolean.FALSE);
     }
 
-    public Optional<Boolean> verifyHOTP(UUID uuid, String token, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public Optional<Boolean> verifyHOTP(UUID uuid, String token) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Verifying HOTP " + uuid + " with " + token);
         }
 
@@ -400,7 +414,7 @@ public class InternalAPI {
             return Optional.of(Boolean.FALSE);
         }
 
-        HOTPCacheData data = hotpCache.get(uuid, k -> getHOTPExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug));
+        HOTPCacheData data = hotpCache.get(uuid, k -> getHOTPExpensive(uuid));
         if (data == null) {
             logger.warn(uuid + " has not been registered.");
             return Optional.empty();
@@ -419,7 +433,7 @@ public class InternalAPI {
         for (int i = 0; i <= 9; i++) {
             try {
                 if (hotp.generateOneTimePassword(data.getKey(), data.getCounter() + i) == intToken) {
-                    setHOTP(uuid, data.getLength(), data.getCounter() + i, data.getKey(), redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug);
+                    setHOTP(uuid, data.getLength(), data.getCounter() + i, data.getKey());
                     verificationCache.put(uuid, Boolean.TRUE);
                     return Optional.of(Boolean.TRUE);
                 }
@@ -432,18 +446,35 @@ public class InternalAPI {
         return Optional.of(Boolean.FALSE);
     }
 
-    private void setHOTP(UUID uuid, long length, long counter, SecretKey key, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private void setHOTP(UUID uuid, long length, long counter, SecretKey key) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Setting new HOTP counter for " + uuid);
         }
 
         // SQL
         HOTPData result = null;
+        result = getHotpData(uuid, length, counter, key, result);
+
+        if (result == null) {
+            return;
+        }
+
+        // Redis
+        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+
+        // Rabbit
+        broadcastResult(result);
+
+        // Cache
+        hotpCache.put(uuid, new HOTPCacheData(length, counter, key));
+    }
+
+    private HOTPData getHotpData(UUID uuid, long length, long counter, SecretKey key, HOTPData result) {
         try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateHOTP(sql, storageConfigNode, uuid, length, counter, key).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateHOTP(sql, storageConfigNode, uuid, length, counter, key).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.updateHOTP(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, length, counter, key).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.updateHOTP(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, length, counter, key).get();
             }
         } catch (ExecutionException ex) {
             logger.error(ex.getMessage(), ex);
@@ -451,27 +482,15 @@ public class InternalAPI {
             logger.error(ex.getMessage(), ex);
             Thread.currentThread().interrupt();
         }
-
-        if (result == null) {
-            return;
-        }
-
-        // Redis
-        Redis.update(result, redisPool, redisConfigNode);
-
-        // Rabbit
-        RabbitMQ.broadcast(result, rabbitConnection);
-
-        // Cache
-        hotpCache.put(uuid, new HOTPCacheData(length, counter, key));
+        return result;
     }
 
-    public boolean seekHOTPCounter(UUID uuid, String[] tokens, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public boolean seekHOTPCounter(UUID uuid, String[] tokens) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Seeking HOTP counter for " + uuid);
         }
 
-        HOTPCacheData data = hotpCache.get(uuid, k -> getHOTPExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug));
+        HOTPCacheData data = hotpCache.get(uuid, k -> getHOTPExpensive(uuid));
         if (data == null) {
             logger.warn(uuid + " has not been registered.");
             return false;
@@ -527,28 +546,17 @@ public class InternalAPI {
 
         // SQL
         HOTPData result = null;
-        try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateHOTP(sql, storageConfigNode, uuid, data.getLength(), counter, data.getKey()).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateHOTP(sql, storageConfigNode, uuid, data.getLength(), counter, data.getKey()).get();
-            }
-        } catch (ExecutionException ex) {
-            logger.error(ex.getMessage(), ex);
-        } catch (InterruptedException ex) {
-            logger.error(ex.getMessage(), ex);
-            Thread.currentThread().interrupt();
-        }
+        result = getHotpData(uuid, data.getLength(), counter, data.getKey(), result);
 
         if (result == null) {
             return false;
         }
 
         // Redis
-        Redis.update(result, redisPool, redisConfigNode);
+        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // Rabbit
-        RabbitMQ.broadcast(result, rabbitConnection);
+        broadcastResult(result);
 
         // Cache
         hotpCache.put(uuid, new HOTPCacheData(data.getLength(), counter, data.getKey()));
@@ -556,50 +564,58 @@ public class InternalAPI {
         return true;
     }
 
-    public boolean hasAuthy(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private void broadcastResult(HOTPData result) {
+        try {
+            RabbitMQ.broadcast(result, getRabbitConnection());
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean hasAuthy(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting Authy status for " + uuid);
         }
 
-        return authyCache.get(uuid, k -> getAuthyExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug)) >= 0L;
+        return authyCache.get(uuid, k -> getAuthyExpensive(uuid)) >= 0L;
     }
 
-    public boolean hasTOTP(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public boolean hasTOTP(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting TOTP status for " + uuid);
         }
 
-        return totpCache.get(uuid, k -> getTOTPExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug)) != null;
+        return totpCache.get(uuid, k -> getTOTPExpensive(uuid)) != null;
     }
 
-    public boolean hasHOTP(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public boolean hasHOTP(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting HOTP status for " + uuid);
         }
 
-        return hotpCache.get(uuid, k -> getHOTPExpensive(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug)) != null;
+        return hotpCache.get(uuid, k -> getHOTPExpensive(uuid)) != null;
     }
 
-    public boolean isRegistered(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public boolean isRegistered(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting registration status for " + uuid);
         }
 
-        return hasAuthy(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug)
-                || hasTOTP(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug)
-                || hasHOTP(uuid, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug);
+        return hasAuthy(uuid)
+                || hasTOTP(uuid)
+                || hasHOTP(uuid);
     }
 
-    private TOTPCacheData getTOTPExpensive(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private TOTPCacheData getTOTPExpensive(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting TOTP for " + uuid);
         }
 
         // Redis
         try {
-            TOTPCacheData result = Redis.getTOTP(uuid, redisPool, redisConfigNode).get();
+            TOTPCacheData result = Redis.getTOTP(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
                 }
                 return result;
@@ -614,22 +630,22 @@ public class InternalAPI {
         // SQL
         try {
             TOTPData result = null;
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.getTOTPData(uuid, sql, storageConfigNode).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.getTOTPData(uuid, sql, storageConfigNode).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.getTOTPData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.getTOTPData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
             }
 
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, redisPool, redisConfigNode).get();
-                RabbitMQ.broadcast(result, rabbitConnection).get();
+                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return new TOTPCacheData(result.getLength(), result.getKey());
             }
-        } catch (ExecutionException ex) {
+        } catch (ExecutionException | IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         } catch (InterruptedException ex) {
             logger.error(ex.getMessage(), ex);
@@ -639,16 +655,16 @@ public class InternalAPI {
         return null;
     }
 
-    private HOTPCacheData getHOTPExpensive(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private HOTPCacheData getHOTPExpensive(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting HOTP for " + uuid);
         }
 
         // Redis
         try {
-            HOTPCacheData result = Redis.getHOTP(uuid, redisPool, redisConfigNode).get();
+            HOTPCacheData result = Redis.getHOTP(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
                 }
                 return result;
@@ -663,22 +679,22 @@ public class InternalAPI {
         // SQL
         try {
             HOTPData result = null;
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.getHOTPData(uuid, sql, storageConfigNode).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.getHOTPData(uuid, sql, storageConfigNode).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.getHOTPData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.getHOTPData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
             }
 
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, redisPool, redisConfigNode).get();
-                RabbitMQ.broadcast(result, rabbitConnection).get();
+                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return new HOTPCacheData(result.getLength(), result.getCounter(), result.getKey());
             }
-        } catch (ExecutionException ex) {
+        } catch (ExecutionException | IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         } catch (InterruptedException ex) {
             logger.error(ex.getMessage(), ex);
@@ -688,16 +704,16 @@ public class InternalAPI {
         return null;
     }
 
-    private long getAuthyExpensive(UUID uuid, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private long getAuthyExpensive(UUID uuid) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting Authy ID for " + uuid);
         }
 
         // Redis
         try {
-            Long result = Redis.getAuthy(uuid, redisPool, redisConfigNode).get();
+            Long result = Redis.getAuthy(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
                 }
                 return result;
@@ -712,22 +728,22 @@ public class InternalAPI {
         // SQL
         try {
             AuthyData result = null;
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.getAuthyData(uuid, sql, storageConfigNode).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.getAuthyData(uuid, sql, storageConfigNode).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.getAuthyData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.getAuthyData(uuid, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
             }
 
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, redisPool, redisConfigNode).get();
-                RabbitMQ.broadcast(result, rabbitConnection).get();
+                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return result.getID();
             }
-        } catch (ExecutionException ex) {
+        } catch (ExecutionException | IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         } catch (InterruptedException ex) {
             logger.error(ex.getMessage(), ex);
@@ -737,18 +753,18 @@ public class InternalAPI {
         return -1L;
     }
 
-    public static void setLogin(UUID uuid, String ip, long ipTime, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public static void setLogin(UUID uuid, String ip, long ipTime) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Setting login for " + uuid + " (" + ip + ")");
         }
 
         // SQL
         LoginData result = null;
         try {
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.updateLogin(sql, storageConfigNode, uuid, ip).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.updateLogin(sql, storageConfigNode, uuid, ip).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.updateLogin(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, ip).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.updateLogin(ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode(), uuid, ip).get();
             }
         } catch (ExecutionException ex) {
             logger.error(ex.getMessage(), ex);
@@ -762,32 +778,36 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ipTime, redisPool, redisConfigNode);
+        Redis.update(result, ipTime, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
-        RabbitMQ.broadcast(result, ipTime, rabbitConnection);
+        try {
+            RabbitMQ.broadcast(result, ipTime, getRabbitConnection());
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+        }
 
         loginCache.put(new ObjectObjectPair<>(uuid, ip), Boolean.TRUE);
     }
 
-    public static boolean getLogin(UUID uuid, String ip, long ipTime, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    public static boolean getLogin(UUID uuid, String ip, long ipTime) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting login for " + uuid + " (" + ip + ")");
         }
 
-        return loginCache.get(new ObjectObjectPair<>(uuid, ip), k -> getLoginExpensive(uuid, ip, ipTime, redisPool, redisConfigNode, rabbitConnection, sql, storageConfigNode, sqlType, debug));
+        return loginCache.get(new ObjectObjectPair<>(uuid, ip), k -> getLoginExpensive(uuid, ip, ipTime));
     }
 
-    private static boolean getLoginExpensive(UUID uuid, String ip, long ipTime, JedisPool redisPool, ConfigurationNode redisConfigNode, Connection rabbitConnection, SQL sql, ConfigurationNode storageConfigNode, SQLType sqlType, boolean debug) {
-        if (debug) {
+    private static boolean getLoginExpensive(UUID uuid, String ip, long ipTime) {
+        if (ConfigUtil.isDebugging()) {
             logger.info("Getting expensive login for " + uuid + " (" + ip + ")");
         }
 
         // Redis
         try {
-            Boolean result = Redis.getLogin(uuid, ip, redisPool, redisConfigNode).get();
+            Boolean result = Redis.getLogin(uuid, ip, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " " + ip + " found in Redis. Value: " + result);
                 }
                 return result;
@@ -802,22 +822,22 @@ public class InternalAPI {
         // SQL
         try {
             LoginData result = null;
-            if (sqlType == SQLType.MySQL) {
-                result = MySQL.getLoginData(uuid, ip, sql, storageConfigNode).get();
-            } else if (sqlType == SQLType.SQLite) {
-                result = SQLite.getLoginData(uuid, ip, sql, storageConfigNode).get();
+            if (ConfigUtil.getSQLType() == SQLType.MySQL) {
+                result = MySQL.getLoginData(uuid, ip, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
+            } else if (ConfigUtil.getSQLType() == SQLType.SQLite) {
+                result = SQLite.getLoginData(uuid, ip, ConfigUtil.getSQL(), ConfigUtil.getStorageConfigNode()).get();
             }
 
             if (result != null) {
-                if (debug) {
+                if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " " + ip + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, ipTime, redisPool, redisConfigNode).get();
-                RabbitMQ.broadcast(result, ipTime, rabbitConnection).get();
+                Redis.update(result, ipTime, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                RabbitMQ.broadcast(result, ipTime, getRabbitConnection()).get();
                 return true;
             }
-        } catch (ExecutionException ex) {
+        } catch (ExecutionException | IOException | TimeoutException ex) {
             logger.error(ex.getMessage(), ex);
         } catch (InterruptedException ex) {
             logger.error(ex.getMessage(), ex);

--- a/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
@@ -105,7 +105,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result);
 
         // RabbitMQ
         broadcastResult(result);
@@ -153,7 +153,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result);
 
         // RabbitMQ
         try {
@@ -209,7 +209,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result);
 
         // RabbitMQ
         try {
@@ -279,7 +279,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.delete(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.delete(uuid);
 
         // RabbitMQ
         rabbitDelete(uuid);
@@ -462,7 +462,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result);
 
         // Rabbit
         broadcastResult(result);
@@ -555,7 +555,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result);
 
         // Rabbit
         broadcastResult(result);
@@ -615,7 +615,7 @@ public class InternalAPI {
 
         // Redis
         try {
-            TOTPCacheData result = Redis.getTOTP(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+            TOTPCacheData result = Redis.getTOTP(uuid).get();
             if (result != null) {
                 if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
@@ -643,7 +643,7 @@ public class InternalAPI {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                Redis.update(result).get();
                 RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return new TOTPCacheData(result.getLength(), result.getKey());
             }
@@ -664,7 +664,7 @@ public class InternalAPI {
 
         // Redis
         try {
-            HOTPCacheData result = Redis.getHOTP(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+            HOTPCacheData result = Redis.getHOTP(uuid).get();
             if (result != null) {
                 if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
@@ -692,7 +692,7 @@ public class InternalAPI {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                Redis.update(result).get();
                 RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return new HOTPCacheData(result.getLength(), result.getCounter(), result.getKey());
             }
@@ -713,7 +713,7 @@ public class InternalAPI {
 
         // Redis
         try {
-            Long result = Redis.getAuthy(uuid, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+            Long result = Redis.getAuthy(uuid).get();
             if (result != null) {
                 if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " found in Redis. Value: " + result);
@@ -741,7 +741,7 @@ public class InternalAPI {
                     logger.info(uuid + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                Redis.update(result).get();
                 RabbitMQ.broadcast(result, getRabbitConnection()).get();
                 return result.getID();
             }
@@ -780,7 +780,7 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ConfigUtil.getIPTime(), ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result, ConfigUtil.getIPTime());
 
         // RabbitMQ
         try {
@@ -807,7 +807,7 @@ public class InternalAPI {
 
         // Redis
         try {
-            Boolean result = Redis.getLogin(uuid, ip, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+            Boolean result = Redis.getLogin(uuid, ip).get();
             if (result != null) {
                 if (ConfigUtil.isDebugging()) {
                     logger.info(uuid + " " + ip + " found in Redis. Value: " + result);
@@ -835,7 +835,7 @@ public class InternalAPI {
                     logger.info(uuid + " " + ip + " found in storage. Value: " + result);
                 }
                 // Update messaging/Redis, force same-thread
-                Redis.update(result, ipTime, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode()).get();
+                Redis.update(result, ipTime).get();
                 RabbitMQ.broadcast(result, ipTime, getRabbitConnection()).get();
                 return true;
             }

--- a/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/InternalAPI.java
@@ -159,7 +159,7 @@ public class InternalAPI {
         try {
             RabbitMQ.broadcast(result, getRabbitConnection());
         } catch (IOException | TimeoutException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         totpCache.put(uuid, new TOTPCacheData(codeLength, key));
@@ -215,7 +215,7 @@ public class InternalAPI {
         try {
             RabbitMQ.broadcast(result, getRabbitConnection());
         } catch (IOException | TimeoutException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         authyCache.put(uuid, result.getID());
@@ -291,7 +291,7 @@ public class InternalAPI {
         try {
             RabbitMQ.delete(uuid, getRabbitConnection());
         } catch (IOException | TimeoutException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -570,7 +570,7 @@ public class InternalAPI {
         try {
             RabbitMQ.broadcast(result, getRabbitConnection());
         } catch (IOException | TimeoutException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -755,7 +755,7 @@ public class InternalAPI {
         return -1L;
     }
 
-    public static void setLogin(UUID uuid, String ip, long ipTime) {
+    public static void setLogin(UUID uuid, String ip) {
         if (ConfigUtil.isDebugging()) {
             logger.info("Setting login for " + uuid + " (" + ip + ")");
         }
@@ -780,13 +780,13 @@ public class InternalAPI {
         }
 
         // Redis
-        Redis.update(result, ipTime, ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
+        Redis.update(result, ConfigUtil.getIPTime(), ConfigUtil.getRedisPool(), ConfigUtil.getRedisConfigNode());
 
         // RabbitMQ
         try {
-            RabbitMQ.broadcast(result, ipTime, getRabbitConnection());
+            RabbitMQ.broadcast(result, ConfigUtil.getIPTime(), getRabbitConnection());
         } catch (IOException | TimeoutException e) {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         loginCache.put(new ObjectObjectPair<>(uuid, ip), Boolean.TRUE);

--- a/Common/src/main/java/me/egg82/tfaplus/services/RabbitMQ.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/RabbitMQ.java
@@ -2,12 +2,6 @@ package me.egg82.tfaplus.services;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Base64;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 import me.egg82.tfaplus.core.AuthyData;
 import me.egg82.tfaplus.core.HOTPData;
 import me.egg82.tfaplus.core.LoginData;
@@ -16,6 +10,13 @@ import me.egg82.tfaplus.utils.RabbitMQUtil;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 public class RabbitMQ {
     private static final Logger logger = LoggerFactory.getLogger(RabbitMQ.class);

--- a/Common/src/main/java/me/egg82/tfaplus/services/Redis.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/Redis.java
@@ -1,11 +1,5 @@
 package me.egg82.tfaplus.services;
 
-import java.util.Base64;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import javax.crypto.spec.SecretKeySpec;
-
 import me.egg82.tfaplus.core.*;
 import me.egg82.tfaplus.extended.ServiceKeys;
 import me.egg82.tfaplus.utils.RedisUtil;
@@ -19,6 +13,12 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public class Redis {
     private static final Logger logger = LoggerFactory.getLogger(Redis.class);

--- a/Common/src/main/java/me/egg82/tfaplus/services/Redis.java
+++ b/Common/src/main/java/me/egg82/tfaplus/services/Redis.java
@@ -5,13 +5,11 @@ import me.egg82.tfaplus.extended.ServiceKeys;
 import me.egg82.tfaplus.utils.RedisUtil;
 import me.egg82.tfaplus.utils.ValidationUtil;
 import ninja.egg82.analytics.utils.JSONUtil;
-import ninja.leaping.configurate.ConfigurationNode;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
 
 import javax.crypto.spec.SecretKeySpec;
@@ -31,9 +29,9 @@ public class Redis {
 
     private Redis() {}
 
-    public static CompletableFuture<Boolean> updateFromQueue(SQLFetchResult sqlResult, long ipTime, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> updateFromQueue(SQLFetchResult sqlResult, long ipTime) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -127,9 +125,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> update(LoginData sqlResult, long ipTime, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> update(LoginData sqlResult, long ipTime) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -176,9 +174,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> update(AuthyData sqlResult, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> update(AuthyData sqlResult) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -201,9 +199,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> update(TOTPData sqlResult, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> update(TOTPData sqlResult) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -228,9 +226,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> update(HOTPData sqlResult, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> update(HOTPData sqlResult) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -256,9 +254,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> delete(String ip, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> delete(String ip) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -293,9 +291,9 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> delete(UUID uuid, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> delete(UUID uuid) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis == null) {
                     return Boolean.FALSE;
                 }
@@ -331,11 +329,11 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Boolean> getLogin(UUID uuid, String ip, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Boolean> getLogin(UUID uuid, String ip) {
         return CompletableFuture.supplyAsync(() -> {
             Boolean result = null;
 
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis != null) {
                     String key = "2faplus:login:" + uuid + "|" + ip;
 
@@ -353,11 +351,11 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<Long> getAuthy(UUID uuid, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<Long> getAuthy(UUID uuid) {
         return CompletableFuture.supplyAsync(() -> {
             Long result = null;
 
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis != null) {
                     String key = "2faplus:authy:" + uuid;
 
@@ -375,11 +373,11 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<TOTPCacheData> getTOTP(UUID uuid, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<TOTPCacheData> getTOTP(UUID uuid) {
         return CompletableFuture.supplyAsync(() -> {
             TOTPCacheData result = null;
 
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis != null) {
                     String key = "2faplus:totp:" + uuid;
 
@@ -398,11 +396,11 @@ public class Redis {
         });
     }
 
-    public static CompletableFuture<HOTPCacheData> getHOTP(UUID uuid, JedisPool pool, ConfigurationNode redisConfigNode) {
+    public static CompletableFuture<HOTPCacheData> getHOTP(UUID uuid) {
         return CompletableFuture.supplyAsync(() -> {
             HOTPCacheData result = null;
 
-            try (Jedis redis = RedisUtil.getRedis(pool, redisConfigNode)) {
+            try (Jedis redis = RedisUtil.getRedis()) {
                 if (redis != null) {
                     String key = "2faplus:hotp:" + uuid;
 

--- a/Common/src/main/java/me/egg82/tfaplus/sql/MySQL.java
+++ b/Common/src/main/java/me/egg82/tfaplus/sql/MySQL.java
@@ -1,12 +1,5 @@
 package me.egg82.tfaplus.sql;
 
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import javax.crypto.SecretKey;
-
 import me.egg82.tfaplus.core.*;
 import me.egg82.tfaplus.utils.ValidationUtil;
 import ninja.egg82.core.SQLQueryResult;
@@ -14,6 +7,14 @@ import ninja.egg82.sql.SQL;
 import ninja.leaping.configurate.ConfigurationNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.crypto.SecretKey;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public class MySQL {
     private static final Logger logger = LoggerFactory.getLogger(MySQL.class);

--- a/Common/src/main/java/me/egg82/tfaplus/sql/SQLite.java
+++ b/Common/src/main/java/me/egg82/tfaplus/sql/SQLite.java
@@ -1,11 +1,5 @@
 package me.egg82.tfaplus.sql;
 
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import javax.crypto.SecretKey;
-
 import me.egg82.tfaplus.core.*;
 import me.egg82.tfaplus.utils.ValidationUtil;
 import ninja.egg82.core.SQLQueryResult;
@@ -13,6 +7,14 @@ import ninja.egg82.sql.SQL;
 import ninja.leaping.configurate.ConfigurationNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.crypto.SecretKey;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public class SQLite {
     private static final Logger logger = LoggerFactory.getLogger(SQLite.class);

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
@@ -1,12 +1,22 @@
 package me.egg82.tfaplus.utils;
 
+import com.authy.AuthyApiClient;
+import com.authy.api.Tokens;
+import com.google.common.collect.ImmutableSet;
+import com.rabbitmq.client.ConnectionFactory;
 import me.egg82.tfaplus.TFAAPI;
+import me.egg82.tfaplus.core.FreezeConfigContainer;
+import me.egg82.tfaplus.enums.SQLType;
 import me.egg82.tfaplus.extended.CachedConfigValues;
 import me.egg82.tfaplus.extended.Configuration;
 import ninja.egg82.service.ServiceLocator;
 import ninja.egg82.service.ServiceNotFoundException;
+import ninja.egg82.sql.SQL;
+import ninja.leaping.configurate.ConfigurationNode;
+import redis.clients.jedis.JedisPool;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 public class ConfigUtil {
     /**
@@ -43,5 +53,75 @@ public class ConfigUtil {
         }
 
         return null;
+    }
+
+    public static @Nullable SQL getSQL()
+    {
+        return getCachedConfig().getSQL();
+    }
+
+    public static Tokens getTokens()
+    {
+        return getCachedConfig().getAuthy().get().getTokens();
+    }
+
+    public static boolean isDebugging() {
+        return getCachedConfig().getDebug();
+    }
+
+    public static long getIPTime() {
+        return getCachedConfig().getIPTime();
+    }
+
+    public static long getVerificationTime() {
+        return getCachedConfig().getVerificationTime();
+    }
+
+    public static ImmutableSet<String> getCommands() {
+        return getCachedConfig().getCommands();
+    }
+
+    public static boolean getForceAuth() {
+        return getCachedConfig().getForceAuth();
+    }
+
+    public static long getMaxAttempts() {
+        return getCachedConfig().getMaxAttempts();
+    }
+
+    public static FreezeConfigContainer getFreeze() {
+        return getCachedConfig().getFreeze();
+    }
+
+    public static ImmutableSet<String> getIgnored() {
+        return getCachedConfig().getIgnored();
+    }
+
+    public static JedisPool getRedisPool() {
+        return getCachedConfig().getRedisPool();
+    }
+
+    public static ConnectionFactory getRabbitConnectionFactory() {
+        return getCachedConfig().getRabbitConnectionFactory();
+    }
+
+    public static SQLType getSQLType() {
+        return getCachedConfig().getSQLType();
+    }
+
+    public static Optional<AuthyApiClient> getAuthy() {
+        return getCachedConfig().getAuthy();
+    }
+
+    public static CachedConfigValues.Builder builder() {
+        return CachedConfigValues.builder();
+    }
+
+    public static ConfigurationNode getStorageConfigNode() {
+        return getConfig().getNode("storage");
+    }
+
+    public static ConfigurationNode getRedisConfigNode() {
+        return getConfig().getNode("redis");
     }
 }

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
@@ -15,7 +15,6 @@ import ninja.egg82.sql.SQL;
 import ninja.leaping.configurate.ConfigurationNode;
 import redis.clients.jedis.JedisPool;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class ConfigUtil {
@@ -23,7 +22,7 @@ public class ConfigUtil {
      * Grabs the config instance from ServiceLocator
      * @return instance of the Configuration class, may return null
      */
-    public static @Nullable Configuration getConfig()
+    public static Configuration getConfig()
     {
         Configuration config;
 
@@ -41,7 +40,7 @@ public class ConfigUtil {
      * Grabs the cached config instance from ServiceLocator
      * @return instance of the CachedConfigValues class, may return null
      */
-    public static @Nullable CachedConfigValues getCachedConfig()
+    public static CachedConfigValues getCachedConfig()
     {
         CachedConfigValues cachedConfig;
 
@@ -55,7 +54,7 @@ public class ConfigUtil {
         return null;
     }
 
-    public static @Nullable SQL getSQL()
+    public static SQL getSQL()
     {
         return getCachedConfig().getSQL();
     }

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
@@ -113,10 +113,6 @@ public class ConfigUtil {
         return getCachedConfig().getAuthy();
     }
 
-    public static CachedConfigValues.Builder builder() {
-        return CachedConfigValues.builder();
-    }
-
     public static ConfigurationNode getStorageConfigNode() {
         return getConfig().getNode("storage");
     }

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ConfigUtil.java
@@ -1,0 +1,47 @@
+package me.egg82.tfaplus.utils;
+
+import me.egg82.tfaplus.TFAAPI;
+import me.egg82.tfaplus.extended.CachedConfigValues;
+import me.egg82.tfaplus.extended.Configuration;
+import ninja.egg82.service.ServiceLocator;
+import ninja.egg82.service.ServiceNotFoundException;
+
+import javax.annotation.Nullable;
+
+public class ConfigUtil {
+    /**
+     * Grabs the config instance from ServiceLocator
+     * @return instance of the Configuration class, may return null
+     */
+    public static @Nullable Configuration getConfig()
+    {
+        Configuration config;
+
+        try {
+            config = ServiceLocator.get(Configuration.class);
+            return config;
+        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
+            TFAAPI.getLogger().error(ex.getMessage(), ex);
+        }
+
+        return null;
+    }
+
+    /**
+     * Grabs the cached config instance from ServiceLocator
+     * @return instance of the CachedConfigValues class, may return null
+     */
+    public static @Nullable CachedConfigValues getCachedConfig()
+    {
+        CachedConfigValues cachedConfig;
+
+        try {
+            cachedConfig = ServiceLocator.get(CachedConfigValues.class);
+            return cachedConfig;
+        } catch (IllegalAccessException | InstantiationException | ServiceNotFoundException ex) {
+            TFAAPI.getLogger().error(ex.getMessage(), ex);
+        }
+
+        return null;
+    }
+}

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ConfigurationVersionUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ConfigurationVersionUtil.java
@@ -2,13 +2,14 @@ package me.egg82.tfaplus.utils;
 
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
-import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 
 public class ConfigurationVersionUtil {
     private ConfigurationVersionUtil() {}

--- a/Common/src/main/java/me/egg82/tfaplus/utils/RabbitMQUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/RabbitMQUtil.java
@@ -3,6 +3,7 @@ package me.egg82.tfaplus.utils;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 

--- a/Common/src/main/java/me/egg82/tfaplus/utils/RedisUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/RedisUtil.java
@@ -1,23 +1,21 @@
 package me.egg82.tfaplus.utils;
 
-import ninja.leaping.configurate.ConfigurationNode;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
 
 public class RedisUtil {
     private RedisUtil() {}
 
-    public static Jedis getRedis(JedisPool pool, ConfigurationNode redisConfigNode) throws JedisException {
-        if (redisConfigNode == null) {
+    public static Jedis getRedis() throws JedisException {
+        if (ConfigUtil.getRedisConfigNode() == null) {
             throw new IllegalArgumentException("redisConfigNode cannot be null.");
         }
 
         Jedis redis = null;
 
-        if (pool != null) {
-            redis = pool.getResource();
-            String pass = redisConfigNode.getNode("password").getString();
+        if (ConfigUtil.getRedisPool() != null) {
+            redis = ConfigUtil.getRedisPool().getResource();
+            String pass = ConfigUtil.getRedisConfigNode().getNode("password").getString();
             if (pass != null && !pass.isEmpty()) {
                 redis.auth(pass);
             }

--- a/Common/src/main/java/me/egg82/tfaplus/utils/ValidationUtil.java
+++ b/Common/src/main/java/me/egg82/tfaplus/utils/ValidationUtil.java
@@ -1,7 +1,8 @@
 package me.egg82.tfaplus.utils;
 
-import java.util.regex.Pattern;
 import org.apache.commons.validator.routines.InetAddressValidator;
+
+import java.util.regex.Pattern;
 
 public class ValidationUtil {
     /**


### PR DESCRIPTION
This PR does the following things

**1)** All requests to configs from the API or its implementation are now handled by ConfigUtils, which has public static getter boilerplate for grabbing what you need


**2)** Removed all unnecessary and excessive parameters from method signatures in the InternalAPI class


Methods in the InternalAPI class now use getters for fields that used to be passed to them from other classes, these fields being moved to getters helps with encapsulation and readability. The parameters that used to be passed to these methods had nothing to do with the classes passing them and were initialized from static methods, so it only makes sense to move them to a utility class as getter boilerplate.


**3)** Code cleanup in InternalAPI & TFAAPI


I removed redundant and or useless code that has become obsolete from the refactoring I've done to the other classes. There is actually a lot more work I could do but I would be here for days.

In addition to this I've moved duplicate code into new private methods inside of InternalAPI as necessary.
